### PR TITLE
ngg846/update upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           node-version: lts/*
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test:ci
-      - run: npm run build
-      - uses: cycjimmy/semantic-release-action@v3
-        id: semantic
-        with:
-          extra_plugins: |
-            @semantic-release/git
+      - run: npx semantic-release --debug
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           node-version: lts/*
+      - run: npm install --no-save @semantic-release/git
       - run: npx semantic-release --debug
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,3 @@ jobs:
       - run: npx semantic-release --debug
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - if: steps.semantic.outputs.new_release_published == 'true'
-        run: >-
-          git push
-          https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           node-version: lts/*
-      - run: npm install --no-save @semantic-release/git
+      - run: npm install --no-save @semantic-release/git semantic-release-plugin-github-breaking-version-tag
       - run: npx semantic-release --debug
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GR2M_RELEASER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GR2M_RELEASER_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
@@ -24,7 +29,7 @@ jobs:
           extra_plugins: |
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.GR2M_PAT_FOR_SEMANTIC_RELEASE }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - if: steps.semantic.outputs.new_release_published == 'true'
         run: >-
           git push

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: "git-merge"
   color: purple
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   merge_method:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9557,6 +9557,8 @@ async function getCommitStatusesStatus(octokit, commitRef) {
         ...github.context.repo,
         ref: commitRef,
     });
+    if (data.statuses === undefined || data.statuses.length === 0)
+        return "success";
     return data.state;
 }
 exports.getCommitStatusesStatus = getCommitStatusesStatus;

--- a/lib/commit.ts
+++ b/lib/commit.ts
@@ -32,5 +32,8 @@ export async function getCommitStatusesStatus(
     ref: commitRef,
   });
 
+  if (data.statuses === undefined || data.statuses.length === 0)
+    return "success";
+
   return data.state as "success" | "pending" | "failure";
 }

--- a/lib/handle-schedule.test.ts
+++ b/lib/handle-schedule.test.ts
@@ -33,8 +33,8 @@ describe("handleSchedule", () => {
 
     expect(mockStdout.mock.calls).toEqual([
       [`Loading open pull requests\n`],
-      [`6 scheduled pull requests found\n`],
-      [`5 due pull requests found\n`],
+      [`7 scheduled pull requests found\n`],
+      [`6 due pull requests found\n`],
       [`https://github.com/gr2m/merge-schedule-action/pull/2 merged\n`],
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/2#issuecomment-22\n`,
@@ -55,8 +55,12 @@ describe("handleSchedule", () => {
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/7#issuecomment-72\n`,
       ],
+      [`https://github.com/gr2m/merge-schedule-action/pull/14 merged\n`],
+      [
+        `Comment created: https://github.com/gr2m/merge-schedule-action/issues/14#issuecomment-142\n`,
+      ],
     ]);
-    expect(createComment.mock.calls).toHaveLength(3);
+    expect(createComment.mock.calls).toHaveLength(4);
     expect(createComment.mock.calls[0][2]).toMatchInlineSnapshot(`
       ":white_check_mark: **Merge Schedule**
       Scheduled on 2022-06-08 (UTC) successfully merged
@@ -97,8 +101,8 @@ describe("handleSchedule", () => {
 
     expect(mockStdout.mock.calls).toEqual([
       [`Loading open pull requests\n`],
-      [`6 scheduled pull requests found\n`],
-      [`5 due pull requests found\n`],
+      [`7 scheduled pull requests found\n`],
+      [`6 due pull requests found\n`],
       [`https://github.com/gr2m/merge-schedule-action/pull/2 merged\n`],
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/2#issuecomment-22\n`,
@@ -118,8 +122,12 @@ describe("handleSchedule", () => {
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/7#issuecomment-72\n`,
       ],
+      [`https://github.com/gr2m/merge-schedule-action/pull/14 merged\n`],
+      [
+        `Comment created: https://github.com/gr2m/merge-schedule-action/issues/14#issuecomment-142\n`,
+      ],
     ]);
-    expect(createComment.mock.calls).toHaveLength(3);
+    expect(createComment.mock.calls).toHaveLength(4);
     expect(createComment.mock.calls[0][2]).toMatchInlineSnapshot(`
       ":white_check_mark: **Merge Schedule**
       Scheduled on 2022-06-08 (UTC) successfully merged

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,10 +3267,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3544,9 +3550,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -3556,10 +3562,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -6759,9 +6769,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true
     },
     "natural-compare": {
@@ -6955,12 +6965,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4279,9 +4279,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.17.tgz",
+      "integrity": "sha512-XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -7473,9 +7473,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.17.tgz",
+      "integrity": "sha512-XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4269,9 +4269,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -7463,9 +7463,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4417,9 +4417,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7546,9 +7546,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-schedule-action",
   "private": true,
-  "version": "0.0.0-development",
+  "version": "2.4.3",
   "description": "GitHub Action to merge pull requests on a scheduled day",
   "repository": "github:gr2m/merge-schedule-action",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -35,14 +35,19 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      "@semantic-release/github",
+      "@semantic-release/npm",
+      "semantic-release-plugin-github-breaking-version-tag",
       [
         "@semantic-release/git",
         {
-          "assets": "dist",
-          "message": "build(release): compiled action for ${nextRelease.version}\n\n[skip ci]"
+          "assets": [
+            "package.json",
+            "dist/*"
+          ],
+          "message": "build(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
         }
-      ],
-      "@semantic-release/github"
+      ]
     ]
   },
   "dependencies": {

--- a/test/mocks/github.ts
+++ b/test/mocks/github.ts
@@ -122,6 +122,19 @@ const pullRequests = [
     },
     labels: [],
   },
+  {
+    number: 14,
+    html_url: githubPullRequestUrl(14),
+    state: "open",
+    body: "Simple body\n/schedule 2022-06-09",
+    head: {
+      sha: "abc123pending-empty",
+      repo: {
+        fork: false,
+      },
+    },
+    labels: [],
+  },
 ];
 const pullRequestComments = pullRequests.map((pullRequest) => {
   let body = "";
@@ -258,7 +271,7 @@ export const githubHandlers = [
         ctx.status(200),
         ctx.json({
           state: req.params.ref.endsWith("success") ? "success" : "pending",
-          statuses: [],
+          statuses: req.params.ref.endsWith("pending-empty") ? [] : ["pending"],
         })
       );
     }


### PR DESCRIPTION
- build(deps): bump vite from 2.9.15 to 2.9.16
- build(deps-dev): bump word-wrap from 1.2.3 to 1.2.4
- build(deps-dev): bump postcss from 8.4.14 to 8.4.31
- fix: allow merging commits with no statuses (#89)
- build(release): compiled action for 2.4.2
- fix: trigger release
- build(deps-dev): bump vite from 2.9.16 to 2.9.17
- fix: bump runner to Node 20 (#96)
- ci(release): use github app token
- ci(release): use latest semantic-release CLI
- ci(release): install `@semantic-release/git` plugin when needed
- ci(release): move git push to release configuration
- ci(release): install `semantic-release-plugin-github-breaking-version-tag` on demand
- build(release): 2.4.3 [skip ci]
